### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ const watch = require('watch-drive')
 // returns a readable stream
 const w = watch(drive, prefix)
 
-for await (const diff of w) {
+for await (const { diff } of w) {
   for (const { type, key } of diff) {
     // type is either 'update' or 'delete'
     // key is the key that changed


### PR DESCRIPTION
The watcher yields objects like
```
{
  key: null,
  length: 0,
  fork: 0,
  diff: [ { type: 'update', key: '/new-file.txt' } ]
}
```

So the `diff` needs to be extracted for the example to work